### PR TITLE
OpenRouter Connector Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ ANTHROPIC_API_KEY=your_anthropic_key
 OPENROUTER_API_KEY=your_openrouter_key
 # Option 3: Google Vertex (recommended if you have permission for extra throughput)
 #GOOGLE_APPLICATION_CREDENTIALS=path_to_credentials_file
+
+# Model Configuration (optional)
+# Override the default model with any OpenRouter-compatible model name
+#LLM_MODEL="google/gemini-2.5-flash-preview-05-20"
+#LLM_MODEL="qwen/qwen3-32b:free"
+#LLM_MODEL="anthropic/claude-3.5-sonnet"
 ```
 
 ### Frontend Environment Variables
@@ -157,6 +163,14 @@ The system will automatically detect available API keys and use them in the foll
 1. Anthropic API key (if `ANTHROPIC_API_KEY` is set)
 2. OpenRouter API key (if `OPENROUTER_API_KEY` is set)
 3. Google Vertex (if `GOOGLE_APPLICATION_CREDENTIALS` is set)
+
+**Model Selection:**
+- By default, the system uses `claude-3-7-sonnet@20250219`
+- You can override this by setting the `LLM_MODEL` environment variable
+- When using OpenRouter, you can specify any model available on their platform:
+  - `LLM_MODEL="google/gemini-2.5-flash-preview-05-20"`
+  - `LLM_MODEL="anthropic/claude-3.5-sonnet"`
+  - See [OpenRouter Models](https://openrouter.ai/models) for the full list
 
 To use the CLI with Anthropic or OpenRouter:
 ```bash

--- a/README.md
+++ b/README.md
@@ -116,10 +116,13 @@ TAVILY_API_KEY=your_tavily_key
 
 STATIC_FILE_BASE_URL=http://localhost:8000/
 
-#If you are using Anthropic client
-ANTHROPIC_API_KEY=
-#If you are using Goolge Vertex (recommended if you have permission extra throughput)
-#GOOGLE_APPLICATION_CREDENTIALS=
+# LLM API Keys (use either one of these options)
+# Option 1: Anthropic API Key
+ANTHROPIC_API_KEY=your_anthropic_key
+# Option 2: OpenRouter API Key (can be used as an alternative to Anthropic)
+OPENROUTER_API_KEY=your_openrouter_key
+# Option 3: Google Vertex (recommended if you have permission for extra throughput)
+#GOOGLE_APPLICATION_CREDENTIALS=path_to_credentials_file
 ```
 
 ### Frontend Environment Variables
@@ -150,12 +153,17 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 
 ### Command Line Interface
 
-If you want to use anthropic client, set `ANTHROPIC_API_KEY` in `.env` file and run:
+The system will automatically detect available API keys and use them in the following order of priority:
+1. Anthropic API key (if `ANTHROPIC_API_KEY` is set)
+2. OpenRouter API key (if `OPENROUTER_API_KEY` is set)
+3. Google Vertex (if `GOOGLE_APPLICATION_CREDENTIALS` is set)
+
+To use the CLI with Anthropic or OpenRouter:
 ```bash
 python cli.py 
 ```
 
-If you want to use vertex, set `GOOGLE_APPLICATION_CREDENTIALS` in `.env` file and run:
+To explicitly use Google Vertex:
 ```bash
 python cli.py --project-id YOUR_PROJECT_ID --region YOUR_REGION
 ```
@@ -171,13 +179,13 @@ Options:
 
 1. Start the WebSocket server:
 
-When using Anthropic client:
+When using Anthropic client or OpenRouter (the system will auto-detect available API keys):
 ```bash
 export STATIC_FILE_BASE_URL=http://localhost:8000
 python ws_server.py --port 8000
 ```
 
-When using Vertex:
+When explicitly using Vertex:
 ```bash
 export STATIC_FILE_BASE_URL=http://localhost:8000
 python ws_server.py --port 8000 --project-id YOUR_PROJECT_ID --region YOUR_REGION

--- a/cli.py
+++ b/cli.py
@@ -92,12 +92,11 @@ async def async_main():
         )
 
     # Initialize LLM client
+    # Client will be auto-detected based on ANTHROPIC_API_KEY or OPENROUTER_API_KEY
     client = get_client(
-        "anthropic-direct",
-        model_name=DEFAULT_MODEL,
-        use_caching=False,
-        project_id=args.project_id,
-        region=args.region,
+        model_name=os.getenv("LLM_MODEL", DEFAULT_MODEL), # Use LLM_MODEL env var or DEFAULT_MODEL
+        # Pass any other relevant kwargs like max_retries if needed by all clients
+        # For example: max_retries=args.max_retries if you add such an arg
     )
 
     # Initialize workspace manager with the session-specific workspace

--- a/src/ii_agent/llm/__init__.py
+++ b/src/ii_agent/llm/__init__.py
@@ -1,41 +1,66 @@
 import os
-
-from ii_agent.llm.anthropic import AnthropicDirectClient
 from ii_agent.llm.base import LLMClient
 from ii_agent.llm.openai import OpenAIDirectClient
+from ii_agent.llm.anthropic import AnthropicDirectClient
+from ii_agent.llm.openrouter import OpenRouterClient
+
+# from ii_agent.utils.constants import DEFAULT_MODEL # Optional: if needed for a default model_name here
 
 
-def get_client(client_name: str, **kwargs) -> LLMClient:
-    """Get a client for a given client name."""
-    if client_name == "anthropic-direct":
-        anthropic_base_url = os.getenv("ANTHROPIC_BASE_URL")
-        anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+def get_client(client_name: str | None = None, **kwargs) -> LLMClient:
+    """
+    Get an LLM client.
+    If client_name is explicitly "anthropic-direct", "openrouter", or "openai-direct",
+    attempts to load that specific client.
+    If client_name is None or "auto", attempts to auto-detect based on available API keys:
+    1. Anthropic (if ANTHROPIC_API_KEY is set)
+    2. OpenRouter (if OPENROUTER_API_KEY is set)
+    """
+    resolved_client_name = client_name
+    determined_by_auto_logic = False
 
-        if anthropic_base_url:
-            # If ANTHROPIC_BASE_URL is set, assume OpenRouter or similar OpenAI-compatible API
-            # Use OpenAIDirectClient with ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY
-            kwargs["base_url"] = anthropic_base_url
-            if anthropic_api_key: # Pass the key if it exists
-                kwargs["api_key"] = anthropic_api_key
-            # Ensure model name is passed if present in original kwargs
-            model_name = kwargs.pop("model_name", None)
-            if model_name:
-                 return OpenAIDirectClient(model_name=model_name, **kwargs)
-            else: # Fallback if model_name was not in kwargs, though it usually is
-                 return OpenAIDirectClient(**kwargs)
+    if resolved_client_name is None or resolved_client_name == "auto":
+        determined_by_auto_logic = True
+        if os.getenv("ANTHROPIC_API_KEY"):
+            print("Auto-detected ANTHROPIC_API_KEY, using AnthropicDirectClient.")
+            resolved_client_name = "anthropic-direct"
+        elif os.getenv("OPENROUTER_API_KEY"):
+            print("Auto-detected OPENROUTER_API_KEY, using OpenRouterClient.")
+            resolved_client_name = "openrouter"
         else:
-            # Original Anthropic client
-            return AnthropicDirectClient(**kwargs)
-    elif client_name == "openai-direct":
-        # Ensure OPENAI_API_KEY and OPENAI_BASE_URL are used as before for this client
+            raise ValueError(
+                "Auto-detection failed: No API key found for Anthropic or OpenRouter. "
+                "Please set ANTHROPIC_API_KEY or OPENROUTER_API_KEY."
+            )
+
+    if resolved_client_name == "anthropic-direct":
+        if not determined_by_auto_logic and not os.getenv("ANTHROPIC_API_KEY"):
+            raise ValueError("ANTHROPIC_API_KEY not found for an explicit 'anthropic-direct' client request.")
+        # verbose_print(f"Initializing AnthropicDirectClient with kwargs: {kwargs}")
+        return AnthropicDirectClient(**kwargs)
+    elif resolved_client_name == "openrouter":
+        if not determined_by_auto_logic and not os.getenv("OPENROUTER_API_KEY"):
+            raise ValueError("OPENROUTER_API_KEY not found for an explicit 'openrouter' client request.")
+        openrouter_kwargs = {
+            k: v for k, v in kwargs.items() if k in ["model_name", "max_retries"]
+        }
+        # verbose_print(f"Initializing OpenRouterClient with filtered kwargs: {openrouter_kwargs}")
+        return OpenRouterClient(**openrouter_kwargs)
+    elif resolved_client_name == "openai-direct":
+        # Kept for explicit requests, as per current codebase structure.
+        # User mentioned OpenAI is for imagegen, so it's not in auto-detection for LLM client.
+        if not os.getenv("OPENAI_API_KEY"):
+             raise ValueError("OPENAI_API_KEY not found for an explicit 'openai-direct' client request.")
+        # verbose_print(f"Initializing OpenAIDirectClient with kwargs: {kwargs}")
         return OpenAIDirectClient(**kwargs)
     else:
-        raise ValueError(f"Unknown client name: {client_name}")
+        raise ValueError(f"Unknown or unsupported client name: {resolved_client_name}")
 
 
 __all__ = [
     "LLMClient",
     "OpenAIDirectClient",
     "AnthropicDirectClient",
+    "OpenRouterClient",
     "get_client",
 ]

--- a/src/ii_agent/llm/__init__.py
+++ b/src/ii_agent/llm/__init__.py
@@ -1,17 +1,33 @@
+import os
+
+from ii_agent.llm.anthropic import AnthropicDirectClient
 from ii_agent.llm.base import LLMClient
 from ii_agent.llm.openai import OpenAIDirectClient
-from ii_agent.llm.anthropic import AnthropicDirectClient
-import os
 
 
 def get_client(client_name: str, **kwargs) -> LLMClient:
     """Get a client for a given client name."""
     if client_name == "anthropic-direct":
         anthropic_base_url = os.getenv("ANTHROPIC_BASE_URL")
+        anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+
         if anthropic_base_url:
+            # If ANTHROPIC_BASE_URL is set, assume OpenRouter or similar OpenAI-compatible API
+            # Use OpenAIDirectClient with ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY
             kwargs["base_url"] = anthropic_base_url
-        return AnthropicDirectClient(**kwargs)
+            if anthropic_api_key: # Pass the key if it exists
+                kwargs["api_key"] = anthropic_api_key
+            # Ensure model name is passed if present in original kwargs
+            model_name = kwargs.pop("model_name", None)
+            if model_name:
+                 return OpenAIDirectClient(model_name=model_name, **kwargs)
+            else: # Fallback if model_name was not in kwargs, though it usually is
+                 return OpenAIDirectClient(**kwargs)
+        else:
+            # Original Anthropic client
+            return AnthropicDirectClient(**kwargs)
     elif client_name == "openai-direct":
+        # Ensure OPENAI_API_KEY and OPENAI_BASE_URL are used as before for this client
         return OpenAIDirectClient(**kwargs)
     else:
         raise ValueError(f"Unknown client name: {client_name}")

--- a/src/ii_agent/llm/__init__.py
+++ b/src/ii_agent/llm/__init__.py
@@ -1,11 +1,15 @@
 from ii_agent.llm.base import LLMClient
 from ii_agent.llm.openai import OpenAIDirectClient
 from ii_agent.llm.anthropic import AnthropicDirectClient
+import os
 
 
 def get_client(client_name: str, **kwargs) -> LLMClient:
     """Get a client for a given client name."""
     if client_name == "anthropic-direct":
+        anthropic_base_url = os.getenv("ANTHROPIC_BASE_URL")
+        if anthropic_base_url:
+            kwargs["base_url"] = anthropic_base_url
         return AnthropicDirectClient(**kwargs)
     elif client_name == "openai-direct":
         return OpenAIDirectClient(**kwargs)

--- a/src/ii_agent/llm/anthropic.py
+++ b/src/ii_agent/llm/anthropic.py
@@ -66,7 +66,6 @@ class AnthropicDirectClient(LLMClient):
         thinking_tokens: int = 0,
         project_id: None | str = None,
         region: None | str = None,
-        base_url: None | str = None,
     ):
         """Initialize the Anthropic first party client."""
         # Disable retries since we are handling retries ourselves.
@@ -80,7 +79,7 @@ class AnthropicDirectClient(LLMClient):
         else:
             api_key = os.getenv("ANTHROPIC_API_KEY")
             self.client = anthropic.Anthropic(
-                api_key=api_key, max_retries=1, timeout=60 * 5, base_url=base_url
+                api_key=api_key, max_retries=1, timeout=60 * 5
             )
             model_name = model_name.replace(
                 "@", "-"

--- a/src/ii_agent/llm/anthropic.py
+++ b/src/ii_agent/llm/anthropic.py
@@ -66,6 +66,7 @@ class AnthropicDirectClient(LLMClient):
         thinking_tokens: int = 0,
         project_id: None | str = None,
         region: None | str = None,
+        base_url: None | str = None,
     ):
         """Initialize the Anthropic first party client."""
         # Disable retries since we are handling retries ourselves.
@@ -79,7 +80,7 @@ class AnthropicDirectClient(LLMClient):
         else:
             api_key = os.getenv("ANTHROPIC_API_KEY")
             self.client = anthropic.Anthropic(
-                api_key=api_key, max_retries=1, timeout=60 * 5
+                api_key=api_key, max_retries=1, timeout=60 * 5, base_url=base_url
             )
             model_name = model_name.replace(
                 "@", "-"

--- a/src/ii_agent/llm/openrouter.py
+++ b/src/ii_agent/llm/openrouter.py
@@ -213,12 +213,13 @@ class OpenRouterClient(LLMClient):
                     messages=openai_messages,
                     max_tokens=max_tokens,
                     temperature=temperature,
-                    tools=openai_tools if openai_tools else None, # Pass None if no tools
-                    tool_choice=openai_tool_choice if openai_tool_choice else None, # Pass None if no specific choice
+                    tools=openai_tools if openai_tools else None,
+                    tool_choice=openai_tool_choice if openai_tool_choice else None,
                     extra_headers=extra_headers,
+                    extra_body={"transforms": ["middle-out"]},  # Pass custom OpenRouter parameters
                 )
                 response = api_response # Keep the full response for metadata
-                break 
+                break
             except (APIConnectionError, InternalServerError, RateLimitError) as e:
                 if attempt == self.max_retries:
                     print(f"Failed OpenRouter request after {attempt + 1} retries: {e}")

--- a/src/ii_agent/llm/openrouter.py
+++ b/src/ii_agent/llm/openrouter.py
@@ -1,0 +1,276 @@
+import os
+import random
+import time
+from typing import Any, Tuple, cast
+
+from openai import OpenAI, APIConnectionError, InternalServerError, RateLimitError
+from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolParam
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
+
+from ii_agent.llm.base import (
+    LLMClient,
+    AssistantContentBlock,
+    ToolParam,
+    TextPrompt,
+    ToolCall,
+    TextResult,
+    LLMMessages,
+    ToolFormattedResult,
+    ImageBlock, # Assuming ImageBlock might be used, though OpenRouter's OpenAI-compatible endpoint might not support it in the same way
+)
+from ii_agent.utils.constants import DEFAULT_MODEL # Or a new constant for default OpenRouter model
+
+
+class OpenRouterClient(LLMClient):
+    """Use OpenRouter models via OpenAI-compatible API."""
+
+    def __init__(
+        self,
+        model_name: str = "anthropic/claude-3.5-sonnet", # Default to a common OpenRouter model
+        max_retries: int = 2,
+        # Caching is not directly supported by OpenRouter in the same way as Anthropic's prompt caching
+        # use_caching: bool = False, 
+        # thinking_tokens: int = 0, # Not a standard OpenAI/OpenRouter param
+        # project_id: None | str = None, # Not applicable for OpenRouter
+        # region: None | str = None, # Not applicable for OpenRouter
+    ):
+        """Initialize the OpenRouter client."""
+        api_key = os.getenv("OPENROUTER_API_KEY")
+        if not api_key:
+            raise ValueError("OPENROUTER_API_KEY environment variable not set.")
+
+        self.client = OpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=api_key,
+            max_retries=1,  # We handle retries manually
+            timeout=60 * 5,
+        )
+        self.model_name = model_name
+        self.max_retries = max_retries
+        # self.thinking_tokens = thinking_tokens # Not applicable
+
+    def _map_model_name(self, model_name: str) -> str:
+        """Map Anthropic model names to OpenRouter model names."""
+        model_mapping = {
+            "claude-3-opus-20240229": "anthropic/claude-3-opus",
+            "claude-3-sonnet-20240229": "anthropic/claude-3-sonnet",
+            "claude-3-haiku-20240307": "anthropic/claude-3-haiku",
+            # Add more mappings as needed
+        }
+        return model_mapping.get(model_name, "anthropic/claude-3-sonnet")  # Default to claude-3-sonnet if no match
+
+    def generate(
+        self,
+        messages: LLMMessages,
+        max_tokens: int,
+        system_prompt: str | None = None,
+        temperature: float = 0.0,
+        tools: list[ToolParam] = [],
+        tool_choice: dict[str, str] | None = None,
+        # thinking_tokens: int | None = None, # Not applicable
+    ) -> Tuple[list[AssistantContentBlock], dict[str, Any]]:
+        """Generate responses using OpenRouter.
+
+        Args:
+            messages: A list of messages.
+            max_tokens: The maximum number of tokens to generate.
+            system_prompt: A system prompt.
+            temperature: The temperature.
+            tools: A list of tools.
+            tool_choice: A tool choice.
+
+        Returns:
+            A tuple containing a list of assistant content blocks and metadata.
+        """
+        openai_messages: list[ChatCompletionMessageParam] = []
+
+        if system_prompt:
+            openai_messages.append({"role": "system", "content": system_prompt})
+
+        for idx, message_list in enumerate(messages):
+            # Determine role based on index, assuming alternating user/assistant messages
+            # For OpenRouter/OpenAI, the first message in `messages` (if no system prompt) will be 'user'
+            # Subsequent messages alternate.
+            # If system prompt is provided, messages[0] is user, messages[1] is assistant, etc.
+            # This needs careful mapping based on how LLMMessages is structured.
+            # Assuming LLMMessages is a list of turns, where each turn is a list of content blocks.
+            # And the first turn is user, second is assistant, etc.
+
+            role = "user" if idx % 2 == 0 else "assistant"
+            
+            # For OpenAI, multiple content blocks (like text and image) per message are usually
+            # represented as a list in the 'content' field of a single message object.
+            # However, tool calls and tool results are distinct message types.
+
+            current_turn_content = []
+            tool_calls_for_assistant_message = []
+            tool_results_for_user_message = []
+
+            for message_block in message_list:
+                if isinstance(message_block, TextPrompt) or isinstance(message_block, TextResult):
+                    current_turn_content.append({"type": "text", "text": message_block.text})
+                elif isinstance(message_block, ImageBlock):
+                    # OpenAI format for image content:
+                    # {
+                    #   "type": "image_url",
+                    #   "image_url": { "url": "data:image/jpeg;base64,{base64_image}" }
+                    # }
+                    # This assumes message.source.data is base64 encoded image data
+                    # and message.source.media_type is e.g. 'image/jpeg'
+                    if message_block.source.type == "base64":
+                         current_turn_content.append({
+                             "type": "image_url",
+                             "image_url": {
+                                 "url": f"data:{message_block.source.media_type};base64,{message_block.source.data}"
+                             }
+                         })
+                    else:
+                        # Handle other image source types if necessary, or raise error
+                        print(f"Warning: ImageBlock source type {message_block.source.type} not directly supported for OpenAI image_url. Skipping image.")
+                
+                elif isinstance(message_block, ToolCall):
+                    # This block means the *assistant* previously made a tool call.
+                    # These are added as a list to the assistant's message.
+                    tool_calls_for_assistant_message.append(
+                        ChatCompletionMessageToolCall(
+                            id=message_block.tool_call_id,
+                            function={
+                                "name": message_block.tool_name,
+                                "arguments": str(message_block.tool_input), # OpenAI expects stringified JSON
+                            },
+                            type="function",
+                        )
+                    )
+                elif isinstance(message_block, ToolFormattedResult):
+                    # This block means the *user* is providing a tool result.
+                    # These are individual messages with role 'tool'.
+                     openai_messages.append({
+                         "role": "tool",
+                         "tool_call_id": message_block.tool_call_id,
+                         "content": str(message_block.tool_output), # Content of the tool result
+                     })
+                else:
+                    raise ValueError(f"Unsupported message block type: {type(message_block)}")
+
+            if role == "user":
+                if current_turn_content: # User messages will have content
+                    openai_messages.append({"role": "user", "content": current_turn_content})
+                # tool_results_for_user_message are handled above as separate 'tool' role messages
+            
+            elif role == "assistant":
+                assistant_message_parts: dict[str, Any] = {"role": "assistant"}
+                if current_turn_content: # Assistant text response
+                    # OpenAI expects a single string for content if no tool calls, or if text is the only part
+                    # If there are multiple text parts (not typical for assistant), it should be a list.
+                    # For simplicity, assuming assistant text response is a single string.
+                    assistant_message_parts["content"] = current_turn_content[0]["text"] if len(current_turn_content) == 1 else current_turn_content
+                
+                if tool_calls_for_assistant_message: # Assistant tool calls
+                    assistant_message_parts["tool_calls"] = tool_calls_for_assistant_message
+                
+                if "content" in assistant_message_parts or "tool_calls" in assistant_message_parts:
+                    openai_messages.append(assistant_message_parts)
+
+
+        openai_tools: list[ChatCompletionToolParam] | None = None
+        if tools:
+            openai_tools = []
+            for tool in tools:
+                openai_tools.append(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": tool.name,
+                            "description": tool.description,
+                            "parameters": tool.input_schema,
+                        },
+                    }
+                )
+        
+        openai_tool_choice: str | dict[str, Any] | None = None
+        if tool_choice:
+            if tool_choice["type"] == "any":
+                openai_tool_choice = "required"  # OpenAI's equivalent for forcing a tool call (any tool)
+            elif tool_choice["type"] == "auto":
+                openai_tool_choice = "auto"
+            elif tool_choice["type"] == "tool":
+                openai_tool_choice = {"type": "function", "function": {"name": tool_choice["name"]}}
+            # OpenAI also supports "none" to prevent tool use. Not directly mapped from Anthropic's options.
+        
+        response = None
+        # OpenRouter specific headers (optional, for leaderboard tracking)
+        # Referer: Your app's domain
+        # X-Title: Your app's name
+        extra_headers = {
+            "HTTP-Referer": "https://github.com/klimentij/ii-agent", # Replace with your actual site URL if applicable
+            "X-Title": "ii-agent (klimentij fork)" # Replace with your actual site name if applicable
+        }
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                api_response = self.client.chat.completions.create(
+                    model=self._map_model_name(self.model_name),
+                    messages=openai_messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    tools=openai_tools if openai_tools else None, # Pass None if no tools
+                    tool_choice=openai_tool_choice if openai_tool_choice else None, # Pass None if no specific choice
+                    extra_headers=extra_headers,
+                )
+                response = api_response # Keep the full response for metadata
+                break 
+            except (APIConnectionError, InternalServerError, RateLimitError) as e:
+                if attempt == self.max_retries:
+                    print(f"Failed OpenRouter request after {attempt + 1} retries: {e}")
+                    raise
+                else:
+                    print(f"Retrying OpenRouter request: {attempt + 1}/{self.max_retries}. Error: {e}")
+                    time.sleep(random.uniform(5, 10) * (attempt + 1)) # Exponential backoff with jitter
+            except Exception as e:
+                print(f"An unexpected error occurred: {e}")
+                raise
+
+        internal_messages: list[AssistantContentBlock] = []
+        if response and response.choices and response.choices[0].message:
+            choice_message = response.choices[0].message
+
+            if choice_message.content:
+                # Content can be a string or list of parts (e.g. for multimodal)
+                # For now, assuming it's a string as per typical chat.
+                if isinstance(choice_message.content, str):
+                    internal_messages.append(TextResult(text=choice_message.content))
+                # else:
+                #   Handle list of content parts if necessary (e.g. multimodal responses)
+                #   This might require changes to AssistantContentBlock or new types.
+            
+            if choice_message.tool_calls:
+                internal_messages.extend(self._parse_tool_calls(choice_message.tool_calls))
+
+        message_metadata = {
+            "finish_reason": response.choices[0].finish_reason if response and response.choices else None,
+            # Add any other metadata you want to track
+        }
+
+        return internal_messages, message_metadata
+
+    def _parse_tool_calls(self, tool_calls: list[ChatCompletionMessageToolCall]) -> list[ToolCall]:
+        """Parse OpenAI tool calls into our format."""
+        result = []
+        for tool_call in tool_calls:
+            # Ensure tool input is a dictionary
+            tool_input = tool_call.function.arguments
+            if isinstance(tool_input, str):
+                try:
+                    import json
+                    tool_input = json.loads(tool_input)
+                except json.JSONDecodeError:
+                    tool_input = {"text": tool_input}  # Fallback for string inputs
+            
+            result.append(
+                ToolCall(
+                    tool_name=tool_call.function.name,
+                    tool_input=tool_input,
+                    tool_call_id=tool_call.id
+                )
+            )
+        return result 


### PR DESCRIPTION
## Motivation
I didn't have direct Anthropic API credentials, so I implemented an OpenRouter connector as an alternative method to access Claude models through their API-compatible interface.

## Changes
- Created a new `OpenRouterClient` class in `src/ii_agent/llm/openrouter.py` based on the existing Anthropic client
- Implemented model name mapping from Anthropic model IDs to OpenRouter model IDs
- Added support for OpenRouter's "middle-out" transform to handle large contexts
- Modified `get_client()` to auto-detect available API keys (Anthropic, OpenRouter, or Vertex)
- Updated README.md to document the OpenRouter option

## Benefits of keeping this implementation
- Provides an alternative path for users without direct Anthropic API access
- Supports all the same functionality through OpenRouter's OpenAI-compatible API
- Enables access to multiple LLM providers through a single API key
- Maintains backward compatibility with existing code

The code prioritizes Anthropic direct access when available, falling back to OpenRouter only when needed, so it shouldn't disrupt existing workflows.