### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2296,6 +2296,10 @@
                             {
                                 "name": "webapp-testing",
                                 "url": "https://github.com/anthropics/skills/tree/main/skills/webapp-testing"
+                            },
+                            {
+                                "name": "mmx-cli",
+                                "url": "https://github.com/MiniMax-AI/cli/tree/main/skill"
                             }
                         ]
                     }
@@ -2351,6 +2355,10 @@
                         {
                             "name": "webapp-testing",
                             "url": "https://github.com/anthropics/skills/tree/main/skills/webapp-testing"
+                        },
+                        {
+                            "name": "mmx-cli",
+                            "url": "https://github.com/MiniMax-AI/cli/tree/main/skill"
                         }
                     ]
                 },


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to the example skill URLs in the Connect Skill guide so the mmx-cli skill is discoverable out of the box
- Users can install via the Connect Skill dialog — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**8 lines changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard.

## Test plan

- Open the Connect Skill dialog → the mmx-cli example URL appears in the guide
- Paste `https://github.com/MiniMax-AI/cli/tree/main/skill` into the GitHub URL field → skill installs successfully
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal