### PR TITLE
fix: replace eval() with safe type lookup in UserInputField to prevent code injection

### DIFF
--- a/src/ii_agent/agents/models/base.py
+++ b/src/ii_agent/agents/models/base.py
@@ -1158,8 +1158,13 @@ class Model(ABC):
                 for input_field in fc.arguments.get("user_input_fields", []):
                     field_type = input_field.get("field_type")
                     try:
+                        _SAFE_TYPES = {
+                            "str": str, "int": int, "float": float, "bool": bool,
+                            "list": list, "dict": dict, "tuple": tuple, "set": set,
+                            "bytes": bytes, "NoneType": type(None),
+                        }
                         python_type = (
-                            eval(field_type) if isinstance(field_type, str) else field_type
+                            _SAFE_TYPES.get(field_type, str) if isinstance(field_type, str) else field_type
                         )
                     except (NameError, SyntaxError):
                         python_type = str  # Default to str if type is invalid

--- a/src/ii_agent/agents/tools/base.py
+++ b/src/ii_agent/agents/tools/base.py
@@ -29,9 +29,17 @@ class UserInputField:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "UserInputField":
+        # Use a safe type lookup instead of eval() to prevent code injection
+        _SAFE_TYPES = {
+            "str": str, "int": int, "float": float, "bool": bool,
+            "list": list, "dict": dict, "tuple": tuple, "set": set,
+            "bytes": bytes, "NoneType": type(None),
+        }
+        field_type_name = data["field_type"]
+        field_type = _SAFE_TYPES.get(field_type_name, str)
         return cls(
             name=data["name"],
-            field_type=eval(data["field_type"]),  # Convert string type name to actual type
+            field_type=field_type,
             description=data["description"],
             value=data["value"],
         )


### PR DESCRIPTION
## Problem

`UserInputField.from_dict()` in `agents/tools/base.py` calls `eval(data["field_type"])` without sanitization. The same pattern exists in `agents/models/base.py:1162`. Since `field_type` originates from LLM tool call arguments (which can be influenced by user prompts via prompt injection), this enables arbitrary Python code execution within the agent process.

An attacker who can influence the LLM's tool call output (via prompt injection) can set `field_type` to `__import__('os').system('id')` to execute arbitrary commands.

**Severity:** High (CVSS 8.8) — LLM tool call context → host Python process execution

## Fix

Replace `eval()` with a static allowlist lookup (`_SAFE_TYPES` dict) that maps type name strings to their Python type objects. Unknown type names default to `str`. This preserves the intended functionality (converting type name strings to type objects) while eliminating the code injection vector.

## Test Plan
- [ ] `UserInputField.from_dict({"name": "x", "field_type": "int", ...})` → field_type is `int`
- [ ] `UserInputField.from_dict({"name": "x", "field_type": "__import__('os').system('id')", ...})` → field_type is `str` (no code execution)
- [ ] `UserInputField.from_dict({"name": "x", "field_type": "unknown", ...})` → field_type is `str` (safe default)

## Security Note

This is a high-severity code injection vulnerability exploitable via prompt injection. The fix replaces `eval()` with a safe allowlist lookup.