### PR TITLE
fix: guard total_cached_tokens against None in Gemini metrics

### DIFF
--- a/src/ii_agent/agents/models/google/interactions.py
+++ b/src/ii_agent/agents/models/google/interactions.py
@@ -978,7 +978,7 @@ class GeminiInteractions(Model):
         metrics.reasoning_tokens = response_usage.total_thought_tokens or 0
         metrics.total_tokens = response_usage.total_tokens
 
-        metrics.cache_read_tokens = response_usage.total_cached_tokens
+        metrics.cache_read_tokens = response_usage.total_cached_tokens or 0
         # raw metrics
         metrics.additional_metrics = response_usage.model_dump()
         return metrics

--- a/src/tests/unit/engine/test_v1_models_google_interactions.py
+++ b/src/tests/unit/engine/test_v1_models_google_interactions.py
@@ -773,6 +773,10 @@ class TestGeminiInteractionsGetMetrics:
         gi = _make_gi()
         assert gi._get_metrics(_make_usage(cached_t=30)).cache_read_tokens == 30
 
+    def test_cache_read_tokens_none(self):
+        gi = _make_gi()
+        assert gi._get_metrics(_make_usage(cached_t=None)).cache_read_tokens == 0
+
     def test_additional_metrics_populated(self):
         gi = _make_gi()
         assert gi._get_metrics(_make_usage()).additional_metrics is not None


### PR DESCRIPTION
### What

`GeminiInteractions._get_metrics` assigns `cache_read_tokens` without a null guard:

```python
# src/ii_agent/agents/models/google/interactions.py:981
metrics.cache_read_tokens = response_usage.total_cached_tokens
```

`total_cached_tokens` is `Optional[int]` and comes back as `None` on a cache miss, so `cache_read_tokens` ends up `None`. That value is later summed in `Metrics.__add__`, which raises `TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'` when metrics are accumulated across turns.

### Fix

Default to `0`, matching the sibling assignments right above it (lines 976-978) and the equivalent handling in `gemini.py:1439`:

```python
metrics.cache_read_tokens = response_usage.total_cached_tokens or 0
```

### Test

Added `test_cache_read_tokens_none` in `TestGeminiInteractionsGetMetrics`, mirroring the existing `test_cache_read_tokens` and asserting that a `None` cached-token count maps to `0`.

### Notes

The test module currently carries a module-level `pytest.skip(...)` left over from an earlier refactor, so the suite is skipped in CI as-is. I confirmed the new case passes locally with the skip temporarily lifted (the whole `TestGeminiInteractionsGetMetrics` class is green). I left the skip untouched to keep this change scoped to the bug fix.
